### PR TITLE
downgrade click

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ setup(
     extras_require={
         "lint": [
             "black>=19.10b0,<=20.8",
+            # click>=8.1.0 is incompatible with black.
+            # https://github.com/psf/black/issues/2964
+            "click<8.1.0",
             "flake8-bugbear",  # flake8 doesn't have a dependency for bugbear plugin
             "flake8>=3.7,<5",
             "isort>=4.3,<5.2.0",


### PR DESCRIPTION
https://github.com/psf/black/issues/2964 にあるように最新のclickでは古いblackが動作しない問題への対処です。
問題になるのは `pysen[lint]` を使ってinstallしたときで、blackは古いversionが入る一方でclickは最新版が入ります (black側でclickの上限を制限していないため)。

`pysen[lint]` でinstallするときにclickのversionを制限することで不整合が起きないようにしました。
別の解決策としてblackの制限を緩めるというのもありますが、コードの変更や動作確認の手間が最小になるこちらの方法をとりました。
blackあるいはclickの最新版を使いたいユーザーは `extras_require` を使わないという方法があるので大きな問題にはならないという認識です。