### PR TITLE
supports python 3.10 as a target version

### DIFF
--- a/pysen/py_version.py
+++ b/pysen/py_version.py
@@ -111,4 +111,5 @@ _PythonVersions = {
     "PY37": PythonVersion(3, 7),
     "PY38": PythonVersion(3, 8),
     "PY39": PythonVersion(3, 9),
+    "PY310": PythonVersion(3, 10),
 }


### PR DESCRIPTION
make pysen available in python 3.10.
