### PR TITLE
Use 'release' event to trigger release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 jobs:
   build:
     name: Build packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
 on:
-  push:
-    tags:
-      - '*'
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 jobs:
   build:
     name: Build packages


### PR DESCRIPTION
There is a limitation that a workflow cannot trigger a new workflow.
https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

Currently, a release is created by `release-drafter`, and that's why the `release` workflow wasn't triggered for the `0.10.2` tag.

As such, I configured the `release` workflow to use the `workflow_dispatch` to publish a new release.
I also removed `push.tags` trigger as we can use the `workflow_dispatch` trigger for the manual release as well, but I don't have a strong opinion about that.