### PR TITLE
Add pysen-test action

### DIFF
--- a/.github/actions/pysen-test/Dockerfile
+++ b/.github/actions/pysen-test/Dockerfile
@@ -1,0 +1,1 @@
+../../../assets/Dockerfile

--- a/.github/actions/pysen-test/action.yml
+++ b/.github/actions/pysen-test/action.yml
@@ -1,0 +1,11 @@
+name: 'pysen-test'
+description: 'Run pysen test'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  entrypoint: '/bin/bash'
+  args:
+    - '-c'
+    # Changing the ownership is required. See the following link for more details:
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+    - "chown -R $(id -u):$(id -g) . && tox --parallel"

--- a/.github/workflows/pysen-test.yml
+++ b/.github/workflows/pysen-test.yml
@@ -9,13 +9,10 @@ jobs:
     name: Run pysen-test
     runs-on: ubuntu-20.04
     timeout-minutes: 15
-    container:
-      image: quay.io/pysen/pysen-test@sha256:e6ecc68fda873bf269de16cbed734a627232b88cbdf7054c0520a31a57439738
     steps:
     - uses: actions/checkout@v2
       with:
         lfs: false
         path: ${{ env.CHECKOUT_PATH }}
-    - name: Run tox
-      run: |
-        tox --parallel
+    - name: Run test
+      uses: ./.github/actions/pysen-test/


### PR DESCRIPTION
I created `pysen-test` action.
The action builds the `Dockerfile` on each CI job and runs `tox` on the built image.

Initially I used the docker image hosted on `quay.io`.
But actually it would be problematic for some PRs like #18 to update the docker image.