### PR TITLE
feat: add python3.11, drop python3.6

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -1,16 +1,17 @@
 # Dockerfile for pysen-test
-FROM alpine:3.14.6
+FROM alpine:3.17
 
-COPY --from=python:3.7.10-alpine3.14 /usr/local/ /usr/local/
-COPY --from=python:3.8.13-alpine3.14 /usr/local/ /usr/local/
-COPY --from=python:3.9.12-alpine3.14 /usr/local/ /usr/local/
-COPY --from=python:3.10.4-alpine3.14 /usr/local/ /usr/local/
+COPY --from=python:3.7.16-alpine3.17 /usr/local/ /usr/local/
+COPY --from=python:3.8.16-alpine3.17 /usr/local/ /usr/local/
+COPY --from=python:3.9.16-alpine3.17 /usr/local/ /usr/local/
+COPY --from=python:3.10.11-alpine3.17 /usr/local/ /usr/local/
+COPY --from=python:3.11.3-alpine3.17 /usr/local/ /usr/local/
 
 RUN apk add --no-cache expat gcc libffi musl-dev \
-    && for MINOR in 7 8 9 10; do \
+    && for MINOR in 7 8 9 10 11; do \
     sed "s|^#!/usr/local/bin/python$|#!/usr/local/bin/python3.${MINOR}|" \
     -i /usr/local/bin/*3.${MINOR}; done
 
 RUN apk add --no-cache bash git \
-    && pip3.10 install --no-cache-dir tox==3.15.0
+    && pip3.11 install --no-cache-dir tox==3.15.0
 ENV TOX_PARALLEL_NO_SPINNER 1

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -1,14 +1,13 @@
 # Dockerfile for pysen-test
 FROM alpine:3.14.6
 
-COPY --from=python:3.6.13-alpine3.14 /usr/local/ /usr/local/
 COPY --from=python:3.7.10-alpine3.14 /usr/local/ /usr/local/
 COPY --from=python:3.8.13-alpine3.14 /usr/local/ /usr/local/
 COPY --from=python:3.9.12-alpine3.14 /usr/local/ /usr/local/
 COPY --from=python:3.10.4-alpine3.14 /usr/local/ /usr/local/
 
 RUN apk add --no-cache expat gcc libffi musl-dev \
-    && for MINOR in 6 7 8 9 10; do \
+    && for MINOR in 7 8 9 10; do \
     sed "s|^#!/usr/local/bin/python$|#!/usr/local/bin/python3.${MINOR}|" \
     -i /usr/local/bin/*3.${MINOR}; done
 

--- a/pysen/py_version.py
+++ b/pysen/py_version.py
@@ -107,7 +107,6 @@ class PythonVersion(VersionRepresentation):
 # NOTE(igarashi): PythonVersion class is immutable
 _PythonVersions = {
     "PY27": PythonVersion(2, 7),
-    "PY36": PythonVersion(3, 6),
     "PY37": PythonVersion(3, 7),
     "PY38": PythonVersion(3, 8),
     "PY39": PythonVersion(3, 9),

--- a/pysen/py_version.py
+++ b/pysen/py_version.py
@@ -111,4 +111,5 @@ _PythonVersions = {
     "PY38": PythonVersion(3, 8),
     "PY39": PythonVersion(3, 9),
     "PY310": PythonVersion(3, 10),
+    "PY311": PythonVersion(3, 11),
 }

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     url="https://github.com/pfnet/pysen",
     license="MIT License",
     classifiers=[
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python",
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX",
@@ -46,7 +47,7 @@ setup(
             "flake8-bugbear",  # flake8 doesn't have a dependency for bugbear plugin
             "flake8>=3.7,<5",
             "isort>=4.3,<5.2.0",
-            "mypy>=0.770,<0.800",
+            "mypy>=0.770,<1.0.0",
         ],
     },
     package_data={"pysen": ["py.typed"]},

--- a/tests/test_py_version.py
+++ b/tests/test_py_version.py
@@ -4,24 +4,24 @@ from pysen.py_version import PythonVersion, VersionRepresentation
 
 
 def test_python_version() -> None:
-    py36 = PythonVersion(3, 6)
+    py37 = PythonVersion(3, 7)
 
-    assert py36 == PythonVersion(3, 6)
-    assert py36 != PythonVersion(3, 7)
+    assert py37 == PythonVersion(3, 7)
+    assert py37 != PythonVersion(3, 8)
 
-    assert py36.version == "3.6"
-    assert py36.full_representation == "Python3.6"
-    assert py36.short_representation == "py36"
+    assert py37.version == "3.7"
+    assert py37.full_representation == "Python3.7"
+    assert py37.short_representation == "py37"
 
-    py368 = PythonVersion(3, 6, 8)
+    py378 = PythonVersion(3, 7, 8)
 
-    assert py368 == PythonVersion(3, 6, 8)
-    assert py368 != PythonVersion(3, 6, 9)
-    assert py368 != py36
+    assert py378 == PythonVersion(3, 7, 8)
+    assert py378 != PythonVersion(3, 7, 9)
+    assert py378 != py37
 
-    assert py368.version == "3.6.8"
-    assert py368.full_representation == "Python3.6.8"
-    assert py368.short_representation == "py36"
+    assert py378.version == "3.7.8"
+    assert py378.full_representation == "Python3.7.8"
+    assert py378.short_representation == "py37"
 
 
 def test_version_ops() -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37}-dacite{110,120,150}-isort43-black20, py37-dacite150-isort{43,50,51}-black{19,20}, py{38,39,310}-dacite150-isort51-black{20,22}, development, latest
+envlist = py37-dacite{110,120,150}-isort43-black20, py37-dacite150-isort{43,50,51}-black{19,20}, py{38,39,310}-dacite150-isort51-black{20,22}, development, latest
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37-dacite{110,120,150}-isort43-black20, py37-dacite150-isort{43,50,51}-black{19,20}, py{38,39,310}-dacite150-isort51-black{20,22}, development, latest
+envlist = py37-dacite{110,120,150}-isort43-black20-mypy078, py37-dacite150-isort{43,50,51}-black{19,20}-mypy078, py{38,39,310}-dacite150-isort51-black{20,22}-mypy078, py311-dacite150-isort51-black22-mypy099, development, latest
 
 [testenv]
 deps =
@@ -13,9 +13,10 @@ deps =
     black19: black==19.10b0
     black20: black==20.8b1
     black22: black==22.10.0
+    mypy078: mypy==0.782
+    mypy099: mypy==0.991
     flake8==4.0.1
     flake8-bugbear==21.9.2
-    mypy==0.782
 
 extras = lint
 commands =


### PR DESCRIPTION
## Motivation / Background
python3.6 has reached EOL(23 Dec 2021): [ref](https://endoflife.date/python).
I want to use python3.11.

## Additional information
- Building a test environment where python3.6 and python3.11 coexist is too complicated to modify. [ref](https://peps.python.org/pep-0563/#enabling-the-future-behavior-in-python-3-7)
- black==22.8.0 support python3.11 : [ref](https://github.com/psf/black/releases/tag/22.8.0)
- mypy==0.991 support python3.11 : [ref](https://mypy-lang.blogspot.com/2022/11/mypy-0990-released.html)

## Related works
- upgrade to py310
  - https://github.com/pfnet/pysen/pull/18
  - https://github.com/pfnet/pysen/pull/15

