### PR TITLE
Ignore flake8 E701/704 because it conflicts with recent black

### DIFF
--- a/pysen/ext/flake8_wrapper.py
+++ b/pysen/ext/flake8_wrapper.py
@@ -66,6 +66,20 @@ class Flake8Setting(SettingBase):
                 "# E501: black may exceed the line-length to follow other style rules"
             )
 
+        if not _contains(new.ignore, "E701"):
+            new.ignore.append("E701")
+            new._comments.append(
+                # cf. https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#e701-e704
+                "# E701: black will collapse implementations of classes and functions consisting solely of ... to a single line"
+            )
+
+        if not _contains(new.ignore, "E704"):
+            new.ignore.append("E704")
+            new._comments.append(
+                # cf. https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#e701-e704
+                "# E704: black will collapse implementations of classes and functions consisting solely of ... to a single line"
+            )
+
         W503_or_504_enabled = _contains(new.ignore, "W503") or _contains(
             new.ignore, "W504"
         )


### PR DESCRIPTION
Due to https://github.com/psf/black/issues/4173, recent black can't be combined with flake8 unless E701 is explicitly disabled.

cf. https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#e701-e704

This PR disables flake8 category E701 and E704.
