### PR TITLE
Add `flake8_ignore` option

### DIFF
--- a/pysen/factory.py
+++ b/pysen/factory.py
@@ -58,6 +58,7 @@ class ConfigureLintOptions:
     mypy_path: Optional[List[pathlib.Path]] = None
     mypy_plugins: Optional[List[MypyPlugin]] = None
     mypy_targets: Optional[List[MypyTarget]] = None
+    flake8_ignore: Optional[List[str]] = None
 
 
 def configure_lint(options: ConfigureLintOptions) -> List[ComponentBase]:
@@ -98,6 +99,8 @@ def configure_lint(options: ConfigureLintOptions) -> List[ComponentBase]:
 
     if options.enable_flake8:
         flake8_setting = Flake8Setting.default()
+        if options.flake8_ignore:
+            flake8_setting.ignore = options.flake8_ignore
         flake8_setting.max_line_length = line_length
         if options.enable_black:
             flake8_setting = flake8_setting.to_black_compatible()


### PR DESCRIPTION
Support `flake8_ignore` options in `[tool.pysen.lint]` section of `pysen.toml` or `pyproject.toml`.

Example

```
[tool.pysen]
version = "0.11.0"

[tool.pysen.lint]
enable_flake8 = true
flake8_ignore = ["W"]
```