### PR TITLE
feat: support isort v6

### DIFF
--- a/pysen/ext/isort_wrapper.py
+++ b/pysen/ext/isort_wrapper.py
@@ -29,9 +29,9 @@ class IsortSectionName(enum.Enum):
 @functools.lru_cache(1)
 def _get_isort_version() -> VersionRepresentation:
     version = get_version("isort")
-    if version.major not in [4, 5]:
+    if version.major not in [4, 5, 6]:
         raise IncompatibleVersionError(
-            "pysen only supports isort versions 4 and 5. "
+            "pysen only supports isort versions 4, 5, and 6. "
             f"version {version} is not supported."
         )
 


### PR DESCRIPTION
Pysen wrapper for isort wouldn't need changes to support v6 because there's only one breaking change, which drops Python 3.8, according to [the release note of isort 6.0.0](https://github.com/PyCQA/isort/releases/tag/6.0.0).