### PR TITLE
Fix flake8 comments: replace placeholder text in E701 and E704 descriptions

### DIFF
--- a/src/pysen/ext/flake8_wrapper.py
+++ b/src/pysen/ext/flake8_wrapper.py
@@ -68,13 +68,13 @@ class Flake8Setting(SettingBase):
         if not _contains(new.ignore, "E701"):
             new.ignore.append("E701")
             new._comments.append(
-                "# (E701) black will collapse ... only functions etc. to a single line"
+                "# (E701) black will collapse multiple statements on one line (colon)"
             )
 
         if not _contains(new.ignore, "E704"):
             new.ignore.append("E704")
             new._comments.append(
-                "# (E704) black will collapse ... only functions etc. to a single line"
+                "# (E704) black will collapse multiple statements on one line (def)"
             )
 
         W503_or_504_enabled = _contains(new.ignore, "W503") or _contains(


### PR DESCRIPTION
Fixes incomplete comments in flake8_wrapper.py where E701 and E704 rule descriptions contained placeholder text '...' instead of proper descriptions.

E701: multiple statements on one line (colon)
E704: multiple statements on one line (def)